### PR TITLE
feat(model-config): add Atlas Cloud as an optional Anthropic-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,10 @@ CALLBACK_TOKEN=change-this-token-in-production
 # Shared OpenAI settings for mem0 (and other OpenAI integrations)
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Atlas Cloud (Anthropic-compatible endpoint, one key for 100+ models)
+# ATLASCLOUD_API_KEY=
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai
 # MEM0_VECTOR_PROVIDER=pgvector
 # MEM0_POSTGRES_HOST=mem0-postgres
 # MEM0_POSTGRES_PORT=5432

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -186,6 +186,8 @@ class Settings(BaseSettings):
     minimax_base_url: str | None = Field(default=None, alias="MINIMAX_BASE_URL")
     deepseek_api_key: str = Field(default="", alias="DEEPSEEK_API_KEY")
     deepseek_base_url: str | None = Field(default=None, alias="DEEPSEEK_BASE_URL")
+    atlascloud_api_key: str = Field(default="", alias="ATLASCLOUD_API_KEY")
+    atlascloud_base_url: str | None = Field(default=None, alias="ATLASCLOUD_BASE_URL")
     openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
     openai_base_url: str | None = Field(default=None, alias="OPENAI_BASE_URL")
     openai_audio_transcription_model: str = Field(

--- a/backend/app/services/model_config_service.py
+++ b/backend/app/services/model_config_service.py
@@ -75,6 +75,19 @@ PROVIDER_SPECS: tuple[ProviderSpec, ...] = (
             ("deepseek-reasoner", "DeepSeek Reasoner"),
         ),
     ),
+    ProviderSpec(
+        provider_id="atlascloud",
+        display_name="Atlas Cloud",
+        api_key_env_key="ATLASCLOUD_API_KEY",
+        base_url_env_key="ATLASCLOUD_BASE_URL",
+        default_base_url="https://api.atlascloud.ai",
+        api_key_settings_fields=("atlascloud_api_key",),
+        base_url_settings_fields=("atlascloud_base_url",),
+        known_models=(
+            ("anthropic/claude-haiku-4.5-20251001", "Claude Haiku 4.5"),
+            ("zai-org/GLM-4.6", "GLM-4.6"),
+        ),
+    ),
 )
 
 PROVIDER_SPEC_MAP = {spec.provider_id: spec for spec in PROVIDER_SPECS}
@@ -91,6 +104,11 @@ def infer_provider_id(model_id: str) -> str | None:
         return None
 
     lowered = value.lower()
+    # Atlas Cloud model ids are always "<vendor>/<model>" and no other provider
+    # here uses a slash, so this must come first: "deepseek-ai/DeepSeek-V3.2-Exp"
+    # would otherwise match the startswith("deepseek-") branch below.
+    if "/" in value:
+        return "atlascloud"
     if lowered.startswith("claude-"):
         return "anthropic"
     if lowered.startswith("glm-") or value.startswith("GLM-"):


### PR DESCRIPTION
## Summary

Adds Atlas Cloud as an optional provider next to the existing Anthropic / GLM / MiniMax / DeepSeek entries. It speaks the same Anthropic-compatible protocol the other three non-Anthropic providers already use, so it slots into `PROVIDER_SPECS` without any new code path.

Nothing changes unless `ATLASCLOUD_API_KEY` is set — no default, no behavior change for existing installs.

## Why This PR

`PROVIDER_SPECS` is already the extension point for Anthropic-compatible backends (`glm` → `open.bigmodel.cn/api/anthropic`, `minimax` → `api.minimaxi.com/anthropic`, `deepseek` → `api.deepseek.com/anthropic`). Atlas Cloud exposes the same protocol at `https://api.atlascloud.ai/v1/messages`, so one `ProviderSpec` entry adds a backend without a second integration shape.

Scope, measured rather than assumed: on that Anthropic endpoint I got 200 from `anthropic/*` ids and from `zai-org/GLM-4.6`. `deepseek-ai/DeepSeek-V3.2-Exp` and `Qwen/Qwen3-235B-A22B-Instruct-2507` both return **400** there — those live on the OpenAI-compatible `/v1/chat/completions` route instead, which this PR does not touch. So this is "another Anthropic-compatible backend", not "one key for every model", and `known_models` reflects only what I saw return 200.

Disclosure: I work at Atlas Cloud. This is a config-level addition — happy to close it if an extra provider isn't wanted here.

## One thing worth reviewing

`infer_provider_id()` matches on prefixes (`deepseek-`, `glm-`, …). Atlas model ids are `<vendor>/<model>`, and `deepseek-ai/DeepSeek-V3.2-Exp` **does** start with `deepseek-` — so a slash check appended after those branches silently routes Atlas models to the DeepSeek provider (wrong key, wrong base URL). I hit exactly this while testing, so the slash check goes **first**, with a comment saying why. No existing provider uses a slash in its model ids, so the four current providers resolve exactly as before.

## Validation

Local, against a real Atlas Cloud key:

- `{default_base_url}/v1/messages` end-to-end, Anthropic protocol, real responses:
  - `anthropic/claude-haiku-4.5-20251001` → HTTP 200, `"OK"`
  - `zai-org/GLM-4.6` → HTTP 200
- `infer_provider_id()` — 12/12 cases, asserting the four existing providers resolve unchanged (`claude-sonnet-4-6`→anthropic, `glm-4.7`/`GLM-5`→glm, `MiniMax-M2.5`→minimax, `deepseek-chat`/`deepseek-reasoner`→deepseek) and that slash-qualified ids resolve to atlascloud
- `humanize_model_name()` / `MODEL_NAME_INDEX` unchanged for existing entries
- `python3 -m py_compile` clean on both touched Python files

Note on `known_models`: I listed only ids I personally got a 200 from, since that list is a UI hint and shouldn't promise more than I verified. `deepseek-ai/DeepSeek-V3.2-Exp` returns 400 on the Anthropic endpoint, so it is deliberately absent. `anthropic/claude-sonnet-4.5-20250929` is also absent for a weaker reason — it returned 429 (rate limited) on every retry, so I never saw a 200 for it; the same-family Haiku id works, so the protocol path is fine. Any model id can still be entered by hand; `known_models` only seeds the picker.

Full backend suite not run — it needs Postgres and the project's uv environment, which I didn't stand up. The touched code is import-light; I exercised it by executing the real `PROVIDER_SPECS` / `infer_provider_id` source directly.
